### PR TITLE
MTU 1504-> 1500

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ struct RuntimeConfig {
 }
 
 // Constants
-const MTU: usize = 1504;
+const MTU: usize = 1500;
 const CHANNEL_BUFFER_SIZE: usize = MTU + 512; // Buffered channels
 const ENCRYPTION_OVERHEAD: usize = 28; // 12 nonce + 16 auth tag
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the `MTU` constant in the `RuntimeConfig` struct within `src/main.rs`. The value of `MTU` has been reduced from `1504` to `1500` to align with standard network MTU sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the maximum transmission unit (MTU) value to 1500, affecting related buffer sizes and device configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->