### PR TITLE
refactor: redone concurency model

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,0 @@
-#[derive(thiserror::Error, Debug)]
-pub enum IpouError {
-    #[error("An unknown error occurred: {0}")]
-    Unknown(String),
-}
-
-pub type Result<T> = std::result::Result<T, IpouError>;

--- a/src/ipou.rs
+++ b/src/ipou.rs
@@ -1,6 +1,0 @@
-use std::net::SocketAddr;
-
-pub struct Peer {
-    pub sock_addr: SocketAddr,
-    pub pub_key: String,
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,39 @@
 use std::net::SocketAddr;
 
+// modules
 pub mod cli;
 pub mod config;
 pub mod crypto;
-pub mod error;
 pub mod net;
+pub mod tasks;
 
+// Constants
+pub const MTU: usize = 1420;
+pub const CHANNEL_BUFFER_SIZE: usize = MTU + 512; // Buffered channels
+pub const ENCRYPTION_OVERHEAD: usize = 28; // 12 nonce + 16 auth tag
+
+// types
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug, Clone)]
 pub struct Peer {
     pub sock_addr: SocketAddr,
     pub pub_key: String,
 }
 
+pub type DecryptedPacket = Vec<u8>;
+#[derive(Debug, Clone)]
+pub enum TunMessage {
+    DecryptedPacket,
+    Shutdown,
+}
+
+pub type EncryptedPacket = (Vec<u8>, SocketAddr);
+#[derive(Debug, Clone)]
+pub enum UdpMessage {
+    EncryptedPacket,
+    Shutdown,
+}
+
+// errors
 #[derive(thiserror::Error, Debug)]
 pub enum IpouError {
     #[error("An unknown error occurred: {0}")]

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use tokio::{
+    net::UdpSocket,
+    sync::mpsc::{Receiver, Sender},
+};
+use tun::AsyncDevice;
+
+use crate::config::{Config, RuntimeConfig};
+
+// Spawned listeners
+pub async fn tun_listener(
+    dev: Arc<AsyncDevice>,
+    conf_clone: Arc<Config>,
+    runtime_conf: Arc<RuntimeConfig>,
+    etx: Sender<crate::EncryptedPacket>,
+) -> crate::Result<()> {
+    let mut tun_buf = [0u8; crate::MTU];
+
+    loop {
+        // Listen for TUN packets
+        let len = dev.recv(&mut tun_buf).await?;
+        // Spawn handler task for each packet
+        if len >= 20 {
+            tokio::spawn(crate::net::handle_tun_packet(
+                tun_buf,
+                len,
+                Arc::clone(&conf_clone),
+                Arc::clone(&runtime_conf),
+                etx.clone(),
+            ));
+        }
+        // Send raw packet + result channel to handler
+    }
+}
+
+pub async fn udp_listener(
+    sock: Arc<UdpSocket>,
+    runtime_conf: Arc<RuntimeConfig>,
+    dtx: Sender<crate::DecryptedPacket>,
+) -> crate::Result<()> {
+    let mut udp_buf = [0u8; crate::MTU + 512];
+    loop {
+        // Listen for UDP packets
+        let (len, peer_addr) = sock.recv_from(&mut udp_buf).await?;
+        // Spawn handler task for each packet
+        if len >= 28 {
+            // 12 bytes nonce + 16 bytes auth tag
+            tokio::spawn(crate::net::handle_udp_packet(
+                udp_buf,
+                len,
+                peer_addr,
+                Arc::clone(&runtime_conf),
+                dtx.clone(),
+            ));
+        };
+        // Send raw packet + result channel to handler
+    }
+}
+
+pub async fn result_coordinator(
+    dev: Arc<AsyncDevice>,
+    sock: Arc<UdpSocket>,
+    mut erx: Receiver<crate::EncryptedPacket>,
+    mut drx: Receiver<crate::DecryptedPacket>,
+) -> crate::Result<()> {
+    // This task coordinates sending decrypted packets to TUN and encrypted packets to UDP
+    // It runs indefinitely, processing packets as they arrive
+
+    #[cfg(debug_assertions)]
+    println!("Starting result coordinator...");
+
+    loop {
+        tokio::select! {
+                   // Receive decrypted packets from channel and send to TUN
+                   Some(decrypted_packet) = drx.recv() => {
+                       match dev.send(&decrypted_packet).await {
+                           Ok(_sent) => {},
+                           Err(_e) => {},
+                       }
+                   }
+
+                   // Receive enccrypted packets from channel and send to UDP
+                   Some((encrypted_packet, peer_addr)) = erx.recv() => {
+                        #[cfg(debug_assertions)]
+                        println!("Sending encrypted packet to peer: {peer_addr}");
+                       match sock.send_to(&encrypted_packet, peer_addr).await {
+                           Ok(sent) => {
+                            #[cfg(debug_assertions)]
+                            println!("Sent {sent} bytes to {peer_addr}");
+                        },
+                           Err(_e) => {},
+                       }
+                   }
+        }
+    }
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -75,8 +75,13 @@ pub async fn result_coordinator(
                    // Receive decrypted packets from channel and send to TUN
                    Some(decrypted_packet) = drx.recv() => {
                        match dev.send(&decrypted_packet).await {
-                           Ok(_sent) => {},
-                           Err(_e) => {},
+                        Ok(sent) => {
+                            #[cfg(debug_assertions)]
+                            println!("Sent {sent} bytes to TUN dev");
+                        },
+                        Err(e) => {
+                        eprintln!("Error sending packet to TUN device: {e}");
+                        },
                        }
                    }
 
@@ -89,7 +94,9 @@ pub async fn result_coordinator(
                             #[cfg(debug_assertions)]
                             println!("Sent {sent} bytes to {peer_addr}");
                         },
-                           Err(_e) => {},
+                           Err(e) => {
+                               eprintln!("Error sending encrypted packet to peer {peer_addr}: {e}");
+                        },
                        }
                    }
         }


### PR DESCRIPTION
This pull request refactors the `ipou` codebase to improve modularity, maintainability, and performance. The most significant changes include reorganizing the code structure, introducing task-based concurrency, and optimizing packet handling. Below is a categorized summary of the key changes:

### Code Structure and Organization
- Moved the `Peer` struct and `IpouError` type from `src/ipou.rs` and `src/error.rs` respectively to `src/lib.rs`, consolidating shared types into a central location. The `error` module was removed. [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL1-L7) [[2]](diffhunk://#diff-d63356e4623dc9fd259a39da32b5b8c401e93a7bd813d8496afb9e113dbe4825L1-L6) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R3-R36)
- Introduced a new `tasks` module in `src/tasks/mod.rs` to encapsulate asynchronous task logic for handling TUN and UDP packets, as well as coordinating results. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R3-R36) [[2]](diffhunk://#diff-d700286c7bc551db6c630cfb5c5403c399bf04ce5f8959c21fb46c9056324c10R1-R97)

### Constants and Type Definitions
- Added constants such as `MTU`, `CHANNEL_BUFFER_SIZE`, and `ENCRYPTION_OVERHEAD` to `src/lib.rs` for centralized configuration.
- Defined new types `DecryptedPacket` and `EncryptedPacket` for better type clarity and consistency.

### Task-Based Concurrency
- Replaced the monolithic `tokio::select!` loop in `src/main.rs` with three concurrent tasks: `tun_listener`, `udp_listener`, and `result_coordinator`. These tasks are spawned using `tokio::spawn` and managed with `tokio::try_join!`. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR75-R105) [[2]](diffhunk://#diff-d700286c7bc551db6c630cfb5c5403c399bf04ce5f8959c21fb46c9056324c10R1-R97)
- Moved the logic for handling TUN and UDP packets to `tun_listener` and `udp_listener` functions in the `tasks` module.

### Packet Handling Optimization
- Updated `handle_tun_packet` and `handle_udp_packet` in `src/net/mod.rs` to use pre-allocated buffers (`[u8; MTU]` and `[u8; MTU + 512]`) instead of slices, reducing memory allocations. [[1]](diffhunk://#diff-4c6a8ac4ba774ab01f57abae00bd7caef7c65b5bf09404c3f9a68b93fa06843bL11-R11) [[2]](diffhunk://#diff-4c6a8ac4ba774ab01f57abae00bd7caef7c65b5bf09404c3f9a68b93fa06843bL46-R53)
- Encapsulated packet processing logic into the `result_coordinator` task to streamline the sending of packets to the TUN device and UDP socket.

### Minor Cleanup
- Removed redundant constants and unused imports from `src/main.rs` after moving them to `src/lib.rs`.

These changes improve the modularity of the codebase by separating concerns, enhance performance through optimized packet handling, and make the code easier to maintain by introducing clear abstractions for tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced improved handling of network packets with new asynchronous tasks for TUN device and UDP socket listeners, as well as a coordinator for packet forwarding.
  * Added new message types and constants for clearer networking and encryption parameter management.

* **Refactor**
  * Restructured main application logic for better modularity and concurrency, delegating packet processing to dedicated tasks.
  * Updated function signatures for packet handlers to use more specific types and fixed-size buffers.

* **Chores**
  * Removed unused error handling and peer-related code for a cleaner codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->