### PR TITLE
Rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,22 +559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "ipou"
-version = "0.1.0"
-dependencies = [
- "base64",
- "chacha20poly1305",
- "clap",
- "rand",
- "serde",
- "serde_yml",
- "thiserror",
- "tokio",
- "tun",
- "x25519-dalek",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +670,22 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "opentun"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chacha20poly1305",
+ "clap",
+ "rand",
+ "serde",
+ "serde_yml",
+ "thiserror",
+ "tokio",
+ "tun",
+ "x25519-dalek",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ipou"
+name = "opentun"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ipou - IP over UDP
+# opentun - IP over UDP VPN
 
-A secure, high-performance IP-over-UDP tunnel implementation written in Rust using async I/O and modern cryptography.
+A secure, high-performance user-space IP-over-UDP tunnel implementation written in Rust using async I/O and modern cryptography.
 
 ## Overview
 
-**ipou** creates a TUN interface that tunnels IP packets over UDP with ChaCha20-Poly1305 encryption. It enables secure communication between peers across networks using Curve25519 key exchange and YAML-based configuration.
+**opentun** creates a TUN interface that tunnels IP packets over UDP with ChaCha20-Poly1305 encryption. It enables secure communication between peers across networks using Curve25519 key exchange and YAML-based configuration.
 
 ## Features
 
@@ -28,8 +28,8 @@ A secure, high-performance IP-over-UDP tunnel implementation written in Rust usi
 ### Installation
 
 ```bash
-git clone https://github.com/yourusername/ipou
-cd ipou
+git clone https://github.com/yourusername/opentun
+cd opentun
 cargo build --release
 ```
 
@@ -39,15 +39,15 @@ Generate cryptographic keys for secure communication:
 
 ```bash
 # Generate a private key
-./target/release/ipou genkey
+./target/release/opentun genkey
 
 # Generate public key from private key
-./target/release/ipou pubkey
+./target/release/opentun pubkey
 ```
 
 ### Configuration
 
-Create a `config.yaml` file or let ipou generate a default one:
+Create a `config.yaml` file or let opentun generate a default one:
 
 ```yaml
 name: "utun0"
@@ -65,10 +65,10 @@ peers:
 
 ```bash
 # Run with configuration file (recommended)
-sudo ./target/release/ipou
+sudo ./target/release/opentun
 
 # CLI arguments (legacy support)
-sudo ./target/release/ipou [NAME] [ADDRESS] [PORT]
+sudo ./target/release/opentun [NAME] [ADDRESS] [PORT]
 ```
 
 ### Using the Helper Script
@@ -82,7 +82,7 @@ chmod +x run.sh
 ## Command Line Options
 
 ```
-Usage: ipou [OPTIONS] [NAME] [ADDRESS] [PORT]
+Usage: opentun [OPTIONS] [NAME] [ADDRESS] [PORT]
 
 Arguments:
   [NAME]     TUN interface name (default: from config)
@@ -132,7 +132,7 @@ Peer A (10.0.0.1)                                    Peer B (10.0.0.2)
           │ 1. Read IP packet                                   │ 6. Write decrypted
           ▼                                                     │    IP packet
 ┌─────────────────┐                                   ┌─────────────────┐
-│  ipou Process   │                                   │  ipou Process   │
+│ opentun Process │                                   │ opentun Process │
 │                 │                                   │                 │
 │ ┌─────────────┐ │                                   │ ┌─────────────┐ │
 │ │ Extract     │ │                                   │ │ Decrypt     │ │
@@ -183,9 +183,9 @@ Legend:
 
 ```bash
 # Generate private key
-PRIVATE_A=$(./target/release/ipou genkey)
+PRIVATE_A=$(./target/release/opentun genkey)
 # Generate public key  
-PUBLIC_A=$(echo "$PRIVATE_A" | ./target/release/ipou pubkey)
+PUBLIC_A=$(echo "$PRIVATE_A" | ./target/release/opentun pubkey)
 ```
 
 2. Create config.yaml:
@@ -205,7 +205,7 @@ peers:
 3. Run:
 
 ```bash
-sudo ./target/release/ipou
+sudo ./target/release/opentun
 ```
 
 **Node B:**
@@ -216,7 +216,7 @@ sudo ./target/release/ipou
 
 ### Network Configuration
 
-After starting ipou, configure routing:
+After starting opentun, configure routing:
 
 ```bash
 # Add route for the tunnel network

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,7 +1,7 @@
 use x25519_dalek::{PublicKey, StaticSecret};
 
-type PrivateKeyBytes = [u8; 32];
-type PublicKeyBytes = [u8; 32];
+pub type PrivateKeyBytes = [u8; 32];
+pub type PublicKeyBytes = [u8; 32];
 
 /// generate a new X25519 keypair ()->(private_key, public_key)
 pub fn generate_keypair() -> (PrivateKeyBytes, PublicKeyBytes) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli;
 pub mod config;
 pub mod crypto;
 pub mod net;
+pub mod proto;
 pub mod tasks;
 
 // Constants

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,1 +1,38 @@
-pub enum Packet {}
+use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::PublicKeyBytes;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Packet {
+    HandshakeInit {
+        sender_pubkey: PublicKeyBytes,
+        timestamp: u64,
+    },
+    HandshakeResponse {
+        success: bool,
+        message: String,
+    },
+    RequestPeer {
+        target_pubkey: PublicKeyBytes,
+    },
+    PeerInfo {
+        pubkey: PublicKeyBytes,
+        endpoint: Option<SocketAddr>,
+        last_seen: u64,
+    },
+    KeepAlive {
+        timestamp: u64,
+    },
+    VpnData(Vec<u8>),
+}
+
+/// Wire format for Packet
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WirePacket {
+    /// Quick discriminant
+    pub packet_type: u8,
+    /// encrypted Packet
+    pub payload: Vec<u8>,
+}

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,0 +1,1 @@
+pub enum Packet {}


### PR DESCRIPTION
This pull request primarily renames the project from `ipou` to `opentun` and introduces a new `proto` module for handling protocol-related functionality. The changes include updates to the project name across various files, improvements to code structure, and the addition of a new data structure for protocol packets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new protocol module with support for various network packet types, including handshake, peer info, keepalive, and VPN data messages.

* **Documentation**
  * Updated all documentation and usage examples to reflect the new project name, "opentun", including installation and command-line instructions.

* **Refactor**
  * Renamed the project and all internal references from "ipou" to "opentun".

* **Other**
  * Made certain cryptographic key types publicly accessible for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->